### PR TITLE
Dockerfile: run setup_directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,11 @@ RUN set -eo pipefail; \
 # override the base image
 COPY src/ /
 
+# setup the directories again to set the proper permissions
+RUN set -eo pipefail; \
+  . /usr/local/containerbase/util.sh; \
+  setup_directories;
+
 # run as user
 # https://github.com/renovatebot/docker-renovate-full/blob/main/Dockerfile
 USER 1000


### PR DESCRIPTION
I found that https://github.com/nabeken/cloudwatchdoggo/pull/12 is failed because Renovate can't install a tool on runtime due to the permission issue.

After the investigation, I noticed that `/usr/loca/go` lost a write access for the group when `Dockerfile` override the contents.

## Solution

Run `setup_directories` shell function again.